### PR TITLE
Conform prosilver templates to 3.1

### DIFF
--- a/styles/prosilver/template/event/index_body_stat_blocks_after.html
+++ b/styles/prosilver/template/event/index_body_stat_blocks_after.html
@@ -1,4 +1,6 @@
 <!-- IF S_THANKS_LIST -->
+<div class="stat-block thanks-list">
 	<h3><a href="{U_THANKS_LIST}">{L_TOP_THANKS_LIST}</a></h3>
 	<p>{THANKS_LIST}</p>
+</div>
 <!-- ENDIF -->

--- a/styles/prosilver/template/event/memberlist_view_content_append.html
+++ b/styles/prosilver/template/event/memberlist_view_content_append.html
@@ -2,7 +2,7 @@
 // <![CDATA[
 function getElement(iElementId)
 {
-   if (document.all) 
+   if (document.all)
    {
       return document.all[iElementId];
    }
@@ -58,7 +58,7 @@ function toggleElement(oElement)
 					<a href="#" onclick="toggleElement( getElement('show_thanked')); return false;">{L_THANKS_LIST}</a>
 					<div id="show_thanked" style="display: none;">{THANKED}</div>
 				</dd>
-			</dl>		
+			</dl>
 		</div>
 		<!-- ENDIF -->
 	</div>

--- a/styles/prosilver/template/event/navbar_header_quick_links_after.html
+++ b/styles/prosilver/template/event/navbar_header_quick_links_after.html
@@ -1,2 +1,2 @@
-<!-- IF S_DISPLAY_TOPLIST --><li class="icon-thanks_toplist"><a href="{U_REPUT_TOPLIST}" title="{L_REPUT_TOPLIST}">{L_TOPLIST}</a></li><!-- ENDIF -->
-<!-- IF S_DISPLAY_THANKSLIST --><li class="icon-thanks"><a href="{U_THANKS_LIST}" title="{L_THANKS_USER}">{L_GRATITUDES}</a></li><!-- ENDIF -->
+<!-- IF S_DISPLAY_TOPLIST --><li class="small-icon icon-thanks_toplist"><a href="{U_REPUT_TOPLIST}" title="{L_REPUT_TOPLIST}">{L_TOPLIST}</a></li><!-- ENDIF -->
+<!-- IF S_DISPLAY_THANKSLIST --><li class="small-icon icon-thanks"><a href="{U_THANKS_LIST}" title="{L_THANKS_USER}">{L_GRATITUDES}</a></li><!-- ENDIF -->

--- a/styles/prosilver/template/event/viewtopic_body_post_buttons_after.html
+++ b/styles/prosilver/template/event/viewtopic_body_post_buttons_after.html
@@ -1,9 +1,9 @@
 <!-- IF  not postrow.S_FIRST_POST_ONLY or postrow.S_ONLY_TOPICSTART -->
 	<!-- IF not postrow.S_GLOBAL_POST_THANKS and not postrow.S_POST_ANONYMOUS and S_FORUM_THANKS and S_USER_LOGGED_IN and not postrow.S_IS_OWN_POST and (not postrow.S_ALREADY_THANKED or postrow.S_REMOVE_THANKS) -->
- 
+
     <li>
 		<a id='lnk_thanks_post{postrow.POST_ID}' href="{postrow.THANKS_LINK}" title="{postrow.THANK_ALT}{postrow.POST_AUTHOR}" class="button icon-button {postrow.THANKS_IMG}"><span>{postrow.THANK_ALT_SHORT}</span></a>
 	</li>
-    
-    <!-- ENDIF -->				
+
+    <!-- ENDIF -->
 <!-- ENDIF -->

--- a/styles/prosilver/template/event/viewtopic_body_postrow_post_notices_after.html
+++ b/styles/prosilver/template/event/viewtopic_body_postrow_post_notices_after.html
@@ -14,7 +14,7 @@
 			<dt>{postrow.THANK_TEXT}{postrow.POST_AUTHOR_FULL}{postrow.THANK_TEXT_2}</dt>
 			<dd>{postrow.THANKS}</dd>
 		</dl>
-		<!-- ENDIF -->	
+		<!-- ENDIF -->
 	</div>
 <!-- ENDIF -->
 </div>

--- a/styles/prosilver/template/memberlist_view_thanks.html
+++ b/styles/prosilver/template/memberlist_view_thanks.html
@@ -2,7 +2,7 @@
 // <![CDATA[
 function getElement(iElementId)
 {
-   if (document.all) 
+   if (document.all)
    {
       return document.all[iElementId];
    }
@@ -27,7 +27,7 @@ function toggleElement(oElement)
 </script>
 <!-- IF THANKS_PROFILELIST_VIEW -->
 <div class="panel bg1">
-	<div class="inner"><span class="corners-top"><span></span></span>
+	<div class="inner">
 	<h3>{L_GRATITUDES}</h3>
 		<!-- IF  S_MOD_THANKS and POSTER_GIVE_COUNT --><ul class="profile-icons"><li class="delete-icon"><a href="{U_CLEAR_LIST_THANKS_GIVE}" title="{L_CLEAR_LIST_THANKS}"><span>{L_CLEAR_LIST_THANKS}</span></a></li></ul><!-- ENDIF -->
 		<dl>
@@ -39,10 +39,10 @@ function toggleElement(oElement)
 			<!-- ENDIF -->
 			</dd>
 		</dl>
-	<span class="corners-bottom"><span></span></span></div>
+	</div>
 </div>
 <div class="panel bg2">
-	<div class="inner"><span class="corners-top"><span></span></span>
+	<div class="inner">
 		<!-- IF  S_MOD_THANKS and POSTER_RECEIVE_COUNT --><ul class="profile-icons"><li class="delete-icon"><a href="{U_CLEAR_LIST_THANKS_RECEIVE}" title="{L_CLEAR_LIST_THANKS}"><span>{L_CLEAR_LIST_THANKS}</span></a></li></ul><!-- ENDIF -->
 		<dl>
 			<dt><strong>{L_RECEIVED}:</strong> {POSTER_RECEIVE_COUNT} {L_THANKS}</dt>
@@ -52,7 +52,7 @@ function toggleElement(oElement)
 			<div id="show_thanked" style="display: none;">{THANKED}</div>
 			<!-- ENDIF -->
 			</dd>
-		</dl>		
-	<span class="corners-bottom"><span></span></span></div>
+		</dl>
+	</div>
 </div>
 <!-- ENDIF -->

--- a/styles/prosilver/template/thanks_results.html
+++ b/styles/prosilver/template/thanks_results.html
@@ -1,62 +1,72 @@
 <!-- INCLUDE overall_header.html -->
 
 <h2>{SEARCH_MATCHES}</h2>
-<!-- IF .pagination or SEARCH_MATCHES -->
-	<div class="pagination">
-		{SEARCH_MATCHES} &bull;
-		<!-- IF .pagination -->
-			<!-- INCLUDE pagination.html -->
-		<!-- ELSE -->
-			{PAGE_NUMBER}
-		<!-- ENDIF -->
-	</div>
-<!-- ENDIF -->
+
 <p><a class="arrow-{S_CONTENT_FLOW_BEGIN}" href="{U_THANKS}" title="{L_THANKS_BACK}">{L_THANKS_BACK}</a></p>
 
-	<!-- BEGIN searchresults -->
-		<div class="search post <!-- IF searchresults.S_ROW_COUNT is odd -->bg1<!-- ELSE -->bg2<!-- ENDIF --><!-- IF searchresults.S_POST_REPORTED --> reported<!-- ENDIF -->">
-			<div class="inner"><span class="corners-top"><span></span></span>
-
-		<div class="postbody">
-			<h3><a href="{searchresults.U_VIEW_POST}">{searchresults.POST_SUBJECT}</a></h3>
-			<div class="content">{searchresults.MESSAGE}</div>
+<!-- IF .pagination or SEARCH_MATCHES -->
+	<div class="action-bar top">
+		<div class="pagination">
+			{SEARCH_MATCHES}
+			<!-- IF .pagination -->
+				<!-- INCLUDE pagination.html -->
+			<!-- ELSE -->
+			 &bull; {PAGE_NUMBER}
+			<!-- ENDIF -->
 		</div>
+	</div>
+<!-- ENDIF -->
+
+	<!-- BEGIN searchresults -->
+		<!-- EVENT search_results_post_before -->
+		<div class="search post <!-- IF searchresults.S_ROW_COUNT is odd -->bg1<!-- ELSE -->bg2<!-- ENDIF --><!-- IF searchresults.S_POST_REPORTED --> reported<!-- ENDIF -->">
+			<div class="inner">
 
 		<dl class="postprofile">
+			<!-- EVENT search_results_postprofile_before -->
 			<dt class="author">{L_POST_BY_AUTHOR} {searchresults.POST_AUTHOR_FULL}</dt>
-			<dd>{searchresults.POST_DATE}</dd>
-			<dd>&nbsp;</dd>
+			<dd class="search-result-date">{searchresults.POST_DATE}</dd>
 			<!-- IF searchresults.FORUM_ID -->
 				<dd><a href="{searchresults.U_VIEW_FORUM}">{L_JUMP_TO_FORUM}</a></dd>
 				<dd><a href="{searchresults.U_VIEW_TOPIC}">{L_JUMP_TO_TOPIC}</a></dd>
 			<!-- ELSE -->
 				<dd><a href="{searchresults.U_VIEW_TOPIC}">{L_JUMP_TO_TOPIC}</a></dd>
 			<!-- ENDIF -->
+			<!-- EVENT search_results_postprofile_after -->
 		</dl>
-		<ul class="searchresults">
-			<li ><a href="{searchresults.U_VIEW_POST}" class="{S_CONTENT_FLOW_END}">{L_JUMP_TO_POST}</a></li>
-		</ul>
-			<span class="corners-bottom"><span></span></span></div>
+
+		<div class="postbody">
+			<h3><a href="{searchresults.U_VIEW_POST}">{searchresults.POST_SUBJECT}</a></h3>
+			<div class="content">{searchresults.MESSAGE}</div>
 		</div>
+
+		<ul class="searchresults">
+			<li><a href="{searchresults.U_VIEW_POST}" class="arrow-{S_CONTENT_FLOW_END}">{L_JUMP_TO_POST}</a></li>
+		</ul>
+			</div>
+		</div>
+		<!-- EVENT search_results_post_after -->
 	<!-- BEGINELSE -->
 		<div class="panel">
-			<div class="inner"><span class="corners-top"><span></span></span>
+			<div class="inner">
 			<strong>{L_NO_SEARCH_RESULTS}</strong>
-			<span class="corners-bottom"><span></span></span></div>
+			</div>
 		</div>
 	<!-- END searchresults -->
 
 <!-- IF .pagination or SEARCH_MATCHES -->
+<div class="action-bar bottom">
 	<div class="pagination">
-		{SEARCH_MATCHES} &bull;
+		{SEARCH_MATCHES}
 		<!-- IF .pagination -->
 			<!-- INCLUDE pagination.html -->
 		<!-- ELSE -->
-			{PAGE_NUMBER}
+		&bull; {PAGE_NUMBER}
 		<!-- ENDIF -->
 	</div>
+</div>
 <!-- ENDIF -->
-<div class="clear"></div>
+
 <!-- INCLUDE jumpbox.html -->
 
 <!-- INCLUDE overall_footer.html -->

--- a/styles/prosilver/template/thankslist_body.html
+++ b/styles/prosilver/template/thankslist_body.html
@@ -1,23 +1,22 @@
 <!-- INCLUDE overall_header.html -->
+
 <h2 class="solo">{PAGE_TITLE}</h2>
 
-	<div class="panel">
-		<div class="inner"><span class="corners-top"><span></span></span>
-			<!-- IF .pagination or TOTAL_USERS -->
-				<div class="pagination">
-					{TOTAL_USERS} &bull;
-					<!-- IF .pagination -->
-						<!-- INCLUDE pagination.html -->
-					<!-- ELSE -->
-						{PAGE_NUMBER}
-					<!-- ENDIF -->
-				</div>
+<!-- IF .pagination or TOTAL_USERS -->
+	<div class="action-bar top">
+		<div class="pagination">
+			{TOTAL_USERS}
+			<!-- IF .pagination -->
+				<!-- INCLUDE pagination.html -->
+			<!-- ELSE -->
+				 &bull; {PAGE_NUMBER}
 			<!-- ENDIF -->
-			<span class="corners-bottom"><span></span></span></div>
+		</div>
 	</div>
-		
+<!-- ENDIF -->
+
 	<div class="forumbg forumbg-table">
-		<div class="inner"><span class="corners-top"><span></span></span>
+		<div class="inner">
 
 			<table class="table1" cellspacing="1">
 				<thead>
@@ -49,20 +48,22 @@
 		<!-- END memberrow -->
 				</tbody>
 			</table>
-		<span class="corners-bottom"><span></span></span></div>
+		</div>
 	</div>
-<hr />
 
 <!-- IF .pagination or TOTAL_USERS -->
-	<div class="pagination">
-		{TOTAL_USERS} &bull;
-		<!-- IF .pagination -->
-			<!-- INCLUDE pagination.html -->
-		<!-- ELSE -->
-			{PAGE_NUMBER}
-		<!-- ENDIF -->
+	<div class="action-bar bottom">
+		<div class="pagination">
+			{TOTAL_USERS}
+			<!-- IF .pagination -->
+				<!-- INCLUDE pagination.html -->
+			<!-- ELSE -->
+				 &bull; {PAGE_NUMBER}
+			<!-- ENDIF -->
+		</div>
 	</div>
 <!-- ENDIF -->
-<div class="clear"></div>
-	<!-- INCLUDE jumpbox.html -->
-	<!-- INCLUDE overall_footer.html -->
+
+<!-- INCLUDE jumpbox.html -->
+
+<!-- INCLUDE overall_footer.html -->

--- a/styles/prosilver/template/toplist_body.html
+++ b/styles/prosilver/template/toplist_body.html
@@ -1,21 +1,19 @@
 <!-- INCLUDE overall_header.html -->
+
 <h2 class="solo">{L_TOPLIST}</h2>
 
-	<div class="panel">
-		<div class="inner"><span class="corners-top"><span></span></span>
-			<div class="pagination">
-				<!-- IF .pagination -->
-					<!-- INCLUDE pagination.html -->
-				<!-- ELSE -->
-					{PAGE_NUMBER}
-				<!-- ENDIF -->
-			</div>
-		<span class="corners-bottom"><span></span></span></div>
+<!-- IF .pagination -->
+<div class="action-bar top">
+	<div class="pagination">
+		<!-- INCLUDE pagination.html -->
 	</div>
-<!-- IF S_THANKS_POST_REPUT_VIEW and not S_FULL_TOPIC_RATING and not S_FULL_FORUM_RATING -->	
+</div>
+<!-- ENDIF -->
+
+<!-- IF S_THANKS_POST_REPUT_VIEW and not S_FULL_TOPIC_RATING and not S_FULL_FORUM_RATING -->
 <h3 class="solo"><a href="{U_SEARCH_POST}" class="forumtitle">{L_RATING_TOP_POST}</a></h3>
 	<div class="forumbg forumbg-table">
-		<div class="inner"><span class="corners-top"><span></span></span>
+		<div class="inner">
 
 			<table class="table1" cellspacing="1">
 				<thead>
@@ -41,14 +39,13 @@
 		<!-- END toppostrow -->
 				</tbody>
 			</table>
-		<span class="corners-bottom"><span></span></span></div>
+		</div>
 	</div>
-<hr />
 <!-- ENDIF -->
-<!-- IF S_THANKS_TOPIC_REPUT_VIEW and not S_FULL_POST_RATING and not S_FULL_FORUM_RATING -->	
+<!-- IF S_THANKS_TOPIC_REPUT_VIEW and not S_FULL_POST_RATING and not S_FULL_FORUM_RATING -->
 <h3 class="solo"><a href="{U_SEARCH_TOPIC}" class="forumtitle">{L_RATING_TOP_TOPIC}</a></h3>
 	<div class="forumbg forumbg-table">
-		<div class="inner"><span class="corners-top"><span></span></span>
+		<div class="inner">
 
 			<table class="table1" cellspacing="1">
 				<thead>
@@ -76,14 +73,13 @@
 		<!-- END toptopicrow -->
 				</tbody>
 			</table>
-		<span class="corners-bottom"><span></span></span></div>
+		</div>
 	</div>
-<hr />
 <!-- ENDIF -->
 <!-- IF S_THANKS_FORUM_REPUT_VIEW and not S_FULL_TOPIC_RATING and not S_FULL_POST_RATING -->
 <h3 class="solo"><a href="{U_SEARCH_FORUM}" class="forumtitle">{L_RATING_TOP_FORUM}</a></h3>
 	<div class="forumbg forumbg-table">
-		<div class="inner"><span class="corners-top"><span></span></span>
+		<div class="inner">
 
 			<table class="table1" cellspacing="1">
 				<thead>
@@ -109,17 +105,18 @@
 		<!-- END topforumrow -->
 				</tbody>
 			</table>
-		<span class="corners-bottom"><span></span></span></div>
+		</div>
 	</div>
-<hr />
 <!-- ENDIF -->
+
+<!-- IF .pagination -->
+<div class="action-bar bottom">
 	<div class="pagination">
-		<!-- IF .pagination -->
-			<!-- INCLUDE pagination.html -->
-		<!-- ELSE -->
-			{PAGE_NUMBER}
-		<!-- ENDIF -->
+		<!-- INCLUDE pagination.html -->
 	</div>
-<div class="clear"></div>
+</div>
+<!-- ENDIF -->
+
 <!-- INCLUDE jumpbox.html -->
+
 <!-- INCLUDE overall_footer.html -->

--- a/styles/prosilver/theme/thanks.css
+++ b/styles/prosilver/theme/thanks.css
@@ -55,43 +55,37 @@ dl.thanks dt {
 	background-repeat: no-repeat;
 	background-position: 5px 95%;		/* Position of topic icon */
 }
+
 /* Icon images
 ---------------------------------------- */
-.icon-thanks, .icon-thanks_toplist {
-	background-position: 0 50%;
-	background-repeat: no-repeat;
-	background-image: none;
-	padding: 1px 0 0 17px;
-}
-
-.icon-thanks					{ background-image: url("./images/icon_thanks.gif") }
-.icon-thanks_toplist			{ background-image: url("./images/icon_thanks_toplist.gif") }
+.icon-thanks			{ background-image: url("./images/icon_thanks.gif") }
+.icon-thanks_toplist	{ background-image: url("./images/icon_thanks_toplist.gif") }
 
 
 /* Profile & navigation icons */
-.thanks-icon:before							
-{ 
-     background-position: -3px -1px; 
-     background-image: url("./images/icons_button_likes.png"); 
-}
-.thanks-icon:hover:before{ background-position: -3px -19px; } 
-
-.removethanks-icon:before							
-{ 
-	background-position: -18px -2px; 
-    background-image: url("./images/icons_button_likes.png"); 
-
-}
-.removethanks-icon:hover:before	{background-position: -18px -20px; } 
-
-.thanks_reput_image_back 
+.thanks-icon:before
 {
-	background:  url(../../../images/rating/reput_star_back.gif); 
+     background-position: -3px -1px;
+     background-image: url("./images/icons_button_likes.png");
+}
+.thanks-icon:hover:before{ background-position: -3px -19px; }
+
+.removethanks-icon:before
+{
+	background-position: -18px -2px;
+    background-image: url("./images/icons_button_likes.png");
+
+}
+.removethanks-icon:hover:before	{background-position: -18px -20px; }
+
+.thanks_reput_image_back
+{
+	background:  url(../../../images/rating/reput_star_back.gif);
 	background-repeat: repeat-x;
 }
-.thanks_reput_image 
+.thanks_reput_image
 {
-	background:  url(../../../images/rating/reput_star_gold.gif); 
+	background:  url(../../../images/rating/reput_star_gold.gif);
 	background-repeat: repeat-x;
 }
 


### PR DESCRIPTION
Fixes https://github.com/rxu/thanks_for_posts/issues/8 and https://github.com/rxu/thanks_for_posts/issues/9 (although not the `<a title="Thanks Toplist &mdash; %d" href="./toplist">` title problem.)

Also: `prosilver/memberlist_view_thanks.html` seems to never be used. Perhaps you can remove it.
