### PR TITLE
Cosmetic fixes - No bold text for language keys 'GIVEN' & 'RECEIVED' (text and URL)

### DIFF
--- a/language/fr/thanks_mod.php
+++ b/language/fr/thanks_mod.php
@@ -48,7 +48,7 @@ $lang = array_merge($lang, array(
 
 	'DISABLE_REMOVE_THANKS'		=> 'La suppression des remerciements a été désactivée par l’administrateur',
 
-	'GIVEN'						=> '<strong>A remercié </strong>',
+	'GIVEN'						=> 'A remercié ',
 	'GLOBAL_INCORRECT_THANKS'	=> 'Vous ne pouvez pas remercier une annonce globale qui n’est pas liée à un forum en particulier.',
 	'GRATITUDES'				=> 'Liste des remerciements',
 
@@ -74,7 +74,7 @@ $lang = array_merge($lang, array(
 	'NOTIFICATION_TYPE_THANKS_GIVE'		=> 'Quelqu’un vous a remercié pour votre message',
 	'NOTIFICATION_TYPE_THANKS_REMOVE'	=> 'Quelqu’un a retiré son remerciement pour votre message',
 
-	'RECEIVED'					=> '<strong>A été remercié </strong>',
+	'RECEIVED'					=> 'A été remercié ',
 	'REMOVE_THANKS'				=> 'Retirer vos remerciements à l’auteur : ',
 	'REMOVE_THANKS_CONFIRM'		=> 'Êtes-vous sûr(e) de vouloir retirer vos remerciements à l’auteur pour son message ?',
 	'REMOVE_THANKS_SHORT'		=> 'Remerciement(s) retiré(s)',

--- a/styles/prosilver/template/event/viewtopic_body_postrow_custom_fields_after.html
+++ b/styles/prosilver/template/event/viewtopic_body_postrow_custom_fields_after.html
@@ -1,4 +1,4 @@
 <!-- IF not postrow.S_POST_ANONYMOUS and postrow.THANKS_COUNTERS_VIEW -->
-    <dd data-user-give-id="{postrow.POSTER_ID}"><!-- IF postrow.POSTER_GIVE_COUNT -->{L_GIVEN}: <a href="{postrow.POSTER_GIVE_COUNT_LINK}">{postrow.POSTER_GIVE_COUNT}</a><!-- ENDIF --></dd>
-    <dd data-user-receive-id="{postrow.POSTER_ID}"><!-- IF postrow.POSTER_RECEIVE_COUNT -->{L_RECEIVED}: <a href="{postrow.POSTER_RECEIVE_COUNT_LINK}">{postrow.POSTER_RECEIVE_COUNT}</a><!-- ENDIF --></dd>
+    <dd class="profile-posts" data-user-give-id="{postrow.POSTER_ID}"><!-- IF postrow.POSTER_GIVE_COUNT --><strong>{L_GIVEN}:</strong> <a href="{postrow.POSTER_GIVE_COUNT_LINK}">{postrow.POSTER_GIVE_COUNT}</a><!-- ENDIF --></dd>
+    <dd class="profile-posts" data-user-receive-id="{postrow.POSTER_ID}"><!-- IF postrow.POSTER_RECEIVE_COUNT --><strong>{L_RECEIVED}:</strong> <a href="{postrow.POSTER_RECEIVE_COUNT_LINK}">{postrow.POSTER_RECEIVE_COUNT}</a><!-- ENDIF --></dd>
 <!-- ENDIF -->

--- a/styles/prosilver/template/memberlist_view_thanks.html
+++ b/styles/prosilver/template/memberlist_view_thanks.html
@@ -39,7 +39,7 @@ function toggleElement(oElement)
 			</ul>
 			<!-- ENDIF -->
 			<dl>
-				<dt><strong>{L_GIVEN}:</strong> {POSTER_GIVE_COUNT}</dt>
+				<dt>{L_GIVEN}: {POSTER_GIVE_COUNT}</dt>
 				<dd>
 					<a href="#" onclick="toggleElement( getElement('show_thanks')); return false;">{L_THANKS_LIST}</a>
 					<div id="show_thanks" style="display: none;">{THANKS}</div>
@@ -57,7 +57,7 @@ function toggleElement(oElement)
 			</ul>
 			<!-- ENDIF -->
 			<dl>
-				<dt><strong>{L_RECEIVED}:</strong> {POSTER_RECEIVE_COUNT}</dt>
+				<dt>{L_RECEIVED}: {POSTER_RECEIVE_COUNT}</dt>
 				<dd>
 					<a href="#" onclick="toggleElement( getElement('show_thanked')); return false;">{L_THANKS_LIST}</a>
 					<div id="show_thanked" style="display: none;">{THANKED}</div>


### PR DESCRIPTION
Hi,

i propose to you two cosmetic fixes.
- No bold text for language keys `GIVEN` & `RECEIVED` in tables of those pages `/thankslist` & `/toplist`
- No bold text on URL for `{postrow.POSTER_GIVE_COUNT_LINK}` &  `{postrow.POSTER_RECEIVE_COUNT_LINK}`

Changed files are:
- Update for FRENCH translation for thanks_mod.php file (Regress because i had add the `<strong>`tags by mistake in my french translation for these two language keys )
- Update for /ext/gfksx/ThanksForPosts/styles/prosilver/template/memberlist_view_thanks.html file
- Update for /ext/gfksx/ThanksForPosts/styles/prosilver/template/event/viewtopic_body_postrow_custom_fields_after.html

Sorry for second commit name "Update for FRENCH translation for memberlist_view_thanks.html file" on `memberlist_view_thanks.html` the good name is "Update for a cosmetic fix for memberlist_view_thanks.html file"
