### PR TITLE
Correction on some bugs with Postgresql

### DIFF
--- a/core/helper.php
+++ b/core/helper.php
@@ -725,7 +725,7 @@ class helper
 			$ex_fid_ary = array_keys($this->auth->acl_getf('!f_read', true));
 			$ex_fid_ary = (sizeof($ex_fid_ary)) ? $ex_fid_ary : false;
 
-			$sql = 'SELECT *, COUNT(poster_id) AS poster_count FROM ' . $this->thanks_table . '
+			$sql = 'SELECT poster_id, COUNT(poster_id) AS poster_count FROM ' . $this->thanks_table . '
 				WHERE ' . $this->db->sql_in_set('poster_id', $poster_list) . '
 					AND ' . $this->db->sql_in_set('forum_id', $ex_fid_ary, true) . '
 				GROUP BY poster_id';
@@ -736,7 +736,7 @@ class helper
 			}
 			$this->db->sql_freeresult($result);
 
-			$sql = 'SELECT *, COUNT(user_id) AS user_count FROM ' . $this->thanks_table . '
+			$sql = 'SELECT user_id, COUNT(user_id) AS user_count FROM ' . $this->thanks_table . '
 				WHERE ' . $this->db->sql_in_set('user_id', $poster_list) . '
 					AND ' . $this->db->sql_in_set('forum_id', $ex_fid_ary, true) . '
 				GROUP BY user_id';

--- a/migrations/v_1_2_8.php
+++ b/migrations/v_1_2_8.php
@@ -81,11 +81,10 @@ class v_1_2_8 extends \phpbb\db\migration\migration
 	public function update_thanks_table()
 	{
 		$thanks_table = $this->table_prefix . 'thanks';
-
-		$sql = 'UPDATE '. $thanks_table . ' t
-			LEFT JOIN ' . POSTS_TABLE . ' p ON  t.post_id = p.post_id
-			SET t.forum_id = p.forum_id, t.topic_id = p.topic_id
-			WHERE t.post_id = p.post_id';
+		$sql = 'UPDATE '. $thanks_table . ' AS t 
+			SET forum_id = p.forum_id, topic_id = p.topic_id 
+			FROM ' . POSTS_TABLE . ' p 
+			WHERE t.post_id = p.post_id AND t.post_id = p.post_id';
 		$this->db->sql_query($sql);
 	}
 }


### PR DESCRIPTION
For migration/\* it's a problem during installation part, and for core it's produced when user open a topic.

Bugs are :
UPDATE phpbb_thanks t LEFT JOIN phpbb_posts p ON t.post_id = p.post_id SET t.forum_id = p.forum_id, t.topic_id = p.topic_id WHERE t.post_id = p.post_id;
ERREUR:  erreur de syntaxe sur ou près de « LEFT »
LIGNE 1 : UPDATE phpbb_thanks t LEFT JOIN phpbb_posts p ON t.post_id =...
(translate : syntax error after "LEFT")

And
SELECT *, COUNT(poster_id) AS poster_count FROM phpbb_thanks WHERE poster_id IN ('48', '2') AND forum_id NOT IN (13, 14) GROUP BY poster_id;
ERREUR:  la colonne « phpbb_thanks.post_id » doit apparaître dans la clause GROUP BY ou doit être utilisé dans une fonction d'agrégat
LIGNE 1 : SELECT *, COUNT(poster_id) AS poster_count FROM phpbb_thanks...
(translate : The column "phpbb_thanks.post_id" must appears in GROUP BY clause or must be used into an aggregate function).
