### PR TITLE
lang-de: Add missing spaces

### DIFF
--- a/language/de/thanks_mod.php
+++ b/language/de/thanks_mod.php
@@ -91,7 +91,7 @@ $lang = array_merge($lang, array(
 
 	'THANK'						=> 'Mal',
 	'THANK_FROM'				=> 'von',
-	'THANK_TEXT_1'				=> 'Folgende Benutzer bedankten sich beim Autor',
+	'THANK_TEXT_1'				=> 'Folgende Benutzer bedankten sich beim Autor ',
 	'THANK_TEXT_2'				=> ' für den Beitrag: ',
 	'THANK_TEXT_2PL'			=> ' für den Beitrag (Insgesamt %d):',
 	'THANK_POST'				=> 'Bedanke dich beim Autor des Beitrags: ',

--- a/language/de_x_sie/thanks_mod.php
+++ b/language/de_x_sie/thanks_mod.php
@@ -91,7 +91,7 @@ $lang = array_merge($lang, array(
 
 	'THANK'						=> 'Mal',
 	'THANK_FROM'				=> 'von',
-	'THANK_TEXT_1'				=> 'Folgende Benutzer bedankten sich beim Autor',
+	'THANK_TEXT_1'				=> 'Folgende Benutzer bedankten sich beim Autor ',
 	'THANK_TEXT_2'				=> ' für den Beitrag: ',
 	'THANK_TEXT_2PL'			=> ' für den Beitrag (Insgesamt %d):',
 	'THANK_POST'				=> 'Bedanken Sie sich beim Autor des Beitrags: ',


### PR DESCRIPTION
Last space for 'THANK_TEXT_1' is missing in German translation.