### PR TITLE
Предложение по EN

### DIFF
--- a/language/en/thanks_mod.php
+++ b/language/en/thanks_mod.php
@@ -64,8 +64,8 @@ $lang = array_merge($lang, array(
 	'NO_VIEW_USERS_THANKS'		=> 'You are not authorised to view the Thanks List.',
 
 	'NOTIFICATION_THANKS_GIVE'	=> array(
-		1 => '<strong>Received thank</strong> from %1$s for the post:',
-		2 => '<strong>Received thanks</strong> from %1$s for the post:',
+		1 => '%1$s <strong>has thanked</strong> you for this post:',
+		2 => '%1$s <strong>has thanked</strong> you for this post:',
 	),
 	'NOTIFICATION_THANKS_REMOVE'=> array(
 		1 => '<strong>Removed thank</strong> from %1$s for the post:',


### PR DESCRIPTION
Давече одна англо-русско-японская переводчица мне написала следующее:
https://siava.ru/forum/viewtopic.php?t=6784&p=695206&hilit=has+thanked#p695206

"Ошибка в английском тексте в уведомлениях:

Received thank from имя-пользователя for the post:…

Существительное thanks в английском всегда пишется в мн. ч.; to thank — это исключительно глагол. Я бы вообще переформатировала как «имя-пользователя has thanked you for this post:»."

Быть может она права? :)