### PR TITLE
phpbb 3.2.4 thankslist action bar location(class) fixed

### DIFF
--- a/styles/prosilver/template/thankslist_body.html
+++ b/styles/prosilver/template/thankslist_body.html
@@ -3,7 +3,7 @@
 <h2 class="solo">{{ PAGE_TITLE }}</h2>
 
 {% if loops.pagination|length or TOTAL_USERS > 0 %}
-	<div class="action-bar top">
+	<div class="action-bar bar-top">
 		<div class="pagination">
 			{{ TOTAL_USERS }}
 			{% if loops.pagination|length %}


### PR DESCRIPTION
in phpbb 3.2.4 the "action-bar" element uses "bar-top" class for alignment, not "top" anymore.
This MR updates the class in `styles/prosilver/template/thankslist_body.html`