### PR TITLE
Update indexes to better filter thanks by user *and* forum

### DIFF
--- a/migrations/v_2_0_8.php
+++ b/migrations/v_2_0_8.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ *
+ * Thanks For Posts.
+ * Adds the ability to thank the author and to use per posts/topics/forum rating system based on the count of thanks.
+ * An extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2020, rxu, https://www.phpbbguru.net
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace gfksx\thanksforposts\migrations;
+
+class v_2_0_8 extends \phpbb\db\migration\migration
+{
+	static public function depends_on()
+	{
+			return ['\gfksx\thanksforposts\migrations\v_2_0_6'];
+	}
+
+	public function update_schema()
+	{
+		return [
+			'drop_keys' => [
+				$this->table_prefix . 'thanks' => ['poster_id'],
+				$this->table_prefix . 'thanks' => ['user_id'],
+			],
+			'add_index' => [
+				$this->table_prefix . 'thanks' => [
+					'poster_id'	=> ['poster_id', 'forum_id'],
+					'user_id'	=> ['user_id', 'forum_id'],
+				],
+			],
+		];
+	}
+
+	public function revert_schema()
+	{
+		return [
+			'drop_keys' => [
+				$this->table_prefix . 'thanks' => ['poster_id'],
+				$this->table_prefix . 'thanks' => ['user_id'],
+			],
+			'add_index' => [
+				$this->table_prefix . 'thanks' => [
+					'poster_id'	=> ['poster_id'],
+					'user_id'	=> ['poster_id'],
+				],
+			],
+		];
+	}
+}


### PR DESCRIPTION
This is somewhat related to [this post](https://www.phpbb.com/community/viewtopic.php?p=15787391#p15787391) on phpBB.com. Although the performance issue with that forum is caused by something else, I noticed a query that had to examine a lot of rows. Here it is:
```
Date: 2021-12-07 09:27:55 Query_time: 15.258525 Rows_examined: 29831: Rows_sent 5 Lock_time: 0.000229 Query_chars: 179

SELECT poster_id, COUNT(poster_id) AS poster_count FROM phpbb_thanks WHERE poster_id IN ('56', '78', '2', '64', '48') AND forum_id NOT IN (27, 9, 64, 29, 4, 3) GROUP BY poster_id;
```

As I recall, this is from `array_all_thanks()` which counts the number of thanks given or received by a user, excluding some select forums. In the query above, one of the user (the founder with ID `2`) received a lot of thanks since the forum's inception and the database has to examine a lot of rows in order to exclude the proper forums. By adding `forum_id` to the `poster_id` index, the entire query can be executed from the index alone without touching the actual rows. The same applies to `user_id`, although it's less likely for a user to give thousands of thanks.

Relevant parts from the EXPLAINs below. Current index:
```
type  | possible_keys      | key       | key_len | ref  | rows  | filtered | Extra
index | forum_id,poster_id | poster_id | 3       | NULL | 30781 | 19.82    | Using where
```
New index:
```
type  | possible_keys      | key       | key_len | ref  | rows | filtered | Extra
range | forum_id,poster_id | poster_id | 6       | NULL | 6755 | 100.00   | Using where; Using index
```