### PR TITLE
Add optional AJAX mode for thanking without page reloads

### DIFF
--- a/acp/acp_thanks_module.php
+++ b/acp/acp_thanks_module.php
@@ -65,6 +65,7 @@ class acp_thanks_module
 				'thanks_profilelist_view'	=> ['lang' => 'THANKS_PROFILELIST_VIEW', 'validate' => 'bool', 'type' => 'radio:yes_no', 'explain' => true],
 				'thanks_number'				=> ['lang' => 'THANKS_NUMBER', 'validate' => 'int:1',	'type' => 'text:4:4', 'explain' => true],
 				'thanks_top_number'			=> ['lang' => 'THANKS_TOP_NUMBER', 'validate' => 'int:0', 'type' => 'text:4:6', 'explain' => true],
+				'thanks_use_ajax'			=> ['lang' => 'THANKS_USE_AJAX', 'validate' => 'bool', 'type' => 'radio:yes_no', 'explain' => true],
 			]
 		];
 

--- a/event/listener.php
+++ b/event/listener.php
@@ -142,6 +142,7 @@ class listener implements EventSubscriberInterface
 			'THANKS_LIST'		=> ($thanks_list != '') ? $thanks_list : false,
 			'S_THANKS_LIST'		=> $this->config['thanks_top_number'] && $thanks_list != '',
 			'L_TOP_THANKS_LIST'	=> $this->config['thanks_top_number'] ? $this->language->lang('REPUT_TOPLIST', (int) $this->config['thanks_top_number']) : false,
+			'S_THANKS_USE_AJAX'		=> (bool) $this->config['thanks_use_ajax'],
 		]);
 	}
 
@@ -274,6 +275,7 @@ class listener implements EventSubscriberInterface
 			'S_DISPLAY_TOPLIST'		=> $this->auth->acl_get('u_viewtoplist') && ($this->config['thanks_post_reput_view'] || $this->config['thanks_topic_reput_view'] || $this->config['thanks_forum_reput_view']),
 			'MINI_THANKS_IMG'		=> $this->user->img('icon_mini_thanks', $this->language->lang('GRATITUDES')),
 			'MINI_TOPLIST_IMG'		=> $this->user->img('icon_mini_toplist', $this->language->lang('TOPLIST')),
+			'S_THANKS_USE_AJAX'		=> (bool) $this->config['thanks_use_ajax'],
 		]);
 	}
 
@@ -288,6 +290,7 @@ class listener implements EventSubscriberInterface
 		$forum_id = (int) $event['forum_id'];
 		$this->template->assign_vars([
 			'S_FORUM_THANKS'	=> (bool) ($this->auth->acl_get('f_thanks', $forum_id)),
+			'S_THANKS_USE_AJAX'		=> (bool) $this->config['thanks_use_ajax'],
 		]);
 	}
 

--- a/event/listener.php
+++ b/event/listener.php
@@ -142,7 +142,7 @@ class listener implements EventSubscriberInterface
 			'THANKS_LIST'		=> ($thanks_list != '') ? $thanks_list : false,
 			'S_THANKS_LIST'		=> $this->config['thanks_top_number'] && $thanks_list != '',
 			'L_TOP_THANKS_LIST'	=> $this->config['thanks_top_number'] ? $this->language->lang('REPUT_TOPLIST', (int) $this->config['thanks_top_number']) : false,
-			'S_THANKS_USE_AJAX'		=> (bool) $this->config['thanks_use_ajax'],
+			'S_THANKS_USE_AJAX'	=> (bool) $this->config['thanks_use_ajax'],
 		]);
 	}
 
@@ -290,7 +290,7 @@ class listener implements EventSubscriberInterface
 		$forum_id = (int) $event['forum_id'];
 		$this->template->assign_vars([
 			'S_FORUM_THANKS'	=> (bool) ($this->auth->acl_get('f_thanks', $forum_id)),
-			'S_THANKS_USE_AJAX'		=> (bool) $this->config['thanks_use_ajax'],
+			'S_THANKS_USE_AJAX'	=> (bool) $this->config['thanks_use_ajax'],
 		]);
 	}
 

--- a/language/en/info_acp_thanks.php
+++ b/language/en/info_acp_thanks.php
@@ -122,6 +122,8 @@ $lang = array_merge($lang, [
 	'THANKS_TIME_VIEW_EXPLAIN'			=> 'If enabled, the post will display the thanks time.',
 	'THANKS_TOP_NUMBER'					=> 'Number of users in top list',
 	'THANKS_TOP_NUMBER_EXPLAIN'			=> 'Specify the number of users to show in the toplist on index. 0 - off displaying toplist.',
+	'THANKS_USE_AJAX'					=> 'Use AJAX (same-page updates)?',
+	'THANKS_USE_AJAX_EXPLAIN'			=> 'Yes = thanking and un-thanking updates the UI directly, without leaving the page; no = thanking and un-thanking causes full-page reloads with confirmation screens',
 	'THANKS_TOPIC_REPUT_VIEW'			=> 'Show topic rating',
 	'THANKS_TOPIC_REPUT_VIEW_EXPLAIN'	=> 'If enabled, topic rating will be displayed when viewing a forum.',
 	'TRUNCATE'							=> 'Clear',

--- a/migrations/v3_2_x_add_ajax_config.php
+++ b/migrations/v3_2_x_add_ajax_config.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ *
+ * Thanks For Posts.
+ * Adds the ability to thank the author and to use per posts/topics/forum rating system based on the count of thanks.
+ * An extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2020, rxu, https://www.phpbbguru.net
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace gfksx\thanksforposts\migrations;
+
+class v3_2_x_add_ajax_config extends \phpbb\db\migration\migration
+{
+	static public function depends_on()
+	{
+			return ['\gfksx\thanksforposts\migrations\v_2_0_8'];
+	}
+
+	public function update_data()
+	{
+		return [
+			['config.add', ['thanks_use_ajax', false]],
+		];
+	}
+}

--- a/styles/all/template/event/overall_footer_body_after.html
+++ b/styles/all/template/event/overall_footer_body_after.html
@@ -1,0 +1,3 @@
+{% if S_THANKS_USE_AJAX %}
+	{% INCLUDEJS 'js/ajax.js' %}
+{% endif %}

--- a/styles/all/template/event/overall_header_stylesheets_after.html
+++ b/styles/all/template/event/overall_header_stylesheets_after.html
@@ -1,0 +1,12 @@
+{% if S_THANKS_USE_AJAX %}
+
+<script>
+	window.thanksForPosts = {
+		l10n: {
+			errorTitle: "{{lang('AJAX_ERROR_TITLE') | e('js')}}",
+			errorMessage: "{{lang('AJAX_ERROR_TEXT') | e('js')}}",
+		}
+	}
+</script>
+
+{% endif %}

--- a/styles/all/theme/js/ajax.js
+++ b/styles/all/theme/js/ajax.js
@@ -52,9 +52,10 @@
 	/** @param {HTMLAnchorElement} $link */
 	const thankHandler = async ($link) => {
 		const $loadingIndicator = phpbb.loadingIndicator()
-		const res = await fetch($link.href)
+		// use HEAD instead of GET, as response body is not used
+		const { ok } = await fetch($link.href, { method: 'HEAD' })
 
-		if (res.ok) {
+		if (ok) {
 			const res = await fetch(window.location.href)
 			const text = await res.text()
 
@@ -73,12 +74,21 @@
 	const unthankHandler = ($link) => {
 		const $loadingIndicator = phpbb.loadingIndicator()
 
+		// Safari needs width and height to be set to ensure media queries are
+		// triggered correctly (mobile vs desktop content)
+		const { width, height } =
+			document.documentElement.getBoundingClientRect()
+
 		const $iframe = Object.assign(document.createElement('iframe'), {
 			src: $link.href,
 			sandbox: 'allow-same-origin allow-forms allow-scripts',
 			// Firefox will not submit form if iframe is `hidden` or
 			// `display: none`, so we place it out of view instead
-			style: 'width: 1; height: 1; position: fixed; top: -10000px',
+			style: `position: fixed;
+				width: ${width}px;
+				height: ${height}px;
+				left: -${width * 2}px;
+				top: -${height * 2}px`,
 			// a11y - hide from assistive technology etc.
 			ariaHidden: 'true',
 		})

--- a/styles/all/theme/js/ajax.js
+++ b/styles/all/theme/js/ajax.js
@@ -7,130 +7,142 @@
 	 * 		alertTime: number,
 	 * 		loadingIndicator: () => JQuery,
 	 * 		alert: (title: string, message: string) => JQuery,
-	 * 		confirm: (
-	 *			msg: string,
-	 * 			callback: (val: boolean) => void,
-	 * 			fadedark?: boolean,
-	 * 		) => JQuery,
+	 * 		confirm: (msg: string, callback: (val: boolean) => void) => JQuery,
 	 * 		clearLoadingTimeout: () => void,
 	 * 	},
-	 * 	thanksForPosts: {
-	 * 		l10n: {
-	 * 			errorTitle: string,
-	 * 			errorMessage: string,
-	 * 		},
-	 * 	},
+	 * 	thanksForPosts: { l10n: { errorTitle: string, errorMessage: string } },
 	 * }}
 	 */
 	const { phpbb, thanksForPosts: { l10n } } = window
 
 	/**
 	 * @param {HTMLAnchorElement} $link
-	 * @param {Document} doc
+	 * @param {Document} replacementDoc
 	 */
-	const getReplacerForLink = ($link, doc) => {
+	const getReplacerForLink = ($link, replacementDoc) => {
 		const $post = $link.closest('.post')
-		const $replacement = doc.getElementById($post.id)
+		const $replacement = replacementDoc.getElementById($post.id)
 
 		if ($replacement) {
-			$replacement.querySelector('.content').replaceWith(
-				$post.querySelector('.content'),
-			)
+			$replacement
+				.querySelector('.content')
+				.replaceWith($post.querySelector('.content'))
 
-			return () => $post.replaceWith($replacement)
+			return () => {
+				const $focused = window.document.activeElement
+
+				$post.replaceWith($replacement)
+
+				// UX - re-focus active element within replacement DOM
+				if ($post.contains($focused)) {
+					;[...$replacement.querySelectorAll('*')]
+						.find(
+							($el) =>
+								($el.id && $el.id === $focused.id) ||
+								($el.href && $el.href === $focused.href),
+						)
+						?.focus()
+				}
+			}
 		}
 
 		return null
 	}
 
-	document.body.addEventListener('click', async (e) => {
-		/** @type {HTMLAnchorElement} link */
-		let $link
+	/** @param {HTMLAnchorElement} $link */
+	const thankHandler = async ($link) => {
+		const $loadingIndicator = phpbb.loadingIndicator()
+		const res = await fetch($link.href)
 
-		if ($link = e.target.closest('a[href*="&thanks="]')) {
-			e.preventDefault()
+		if (res.ok) {
+			const res = await fetch(window.location.href)
+			const text = await res.text()
 
-			const $loadingIndicator = phpbb.loadingIndicator()
-			const res = await fetch($link.href)
+			const resDoc = new DOMParser().parseFromString(text, 'text/html')
 
-			if (res.ok) {
-				const res = await fetch(window.location.href)
-				const text = await res.text()
+			getReplacerForLink($link, resDoc)?.()
+		} else {
+			phpbb.alert(l10n.errorTitle, l10n.errorMessage)
+		}
 
-				const doc = new DOMParser().parseFromString(text, 'text/html')
+		phpbb.clearLoadingTimeout()
+		$loadingIndicator.fadeOut(phpbb.alertTime)
+	}
 
-				getReplacerForLink($link, doc)?.()
-			} else {
-				phpbb.alert(l10n.errorTitle, l10n.errorMessage)
+	/** @param {HTMLAnchorElement} $link */
+	const unthankHandler = ($link) => {
+		const $loadingIndicator = phpbb.loadingIndicator()
+
+		const $iframe = Object.assign(document.createElement('iframe'), {
+			src: $link.href,
+			sandbox: 'allow-same-origin allow-forms allow-scripts',
+			// Firefox will not submit form if iframe is `hidden` or
+			// `display: none`, so we place it out of view instead
+			style: 'width: 1; height: 1; position: fixed; top: -10000px',
+			// a11y - hide from assistive technology etc.
+			ariaHidden: 'true',
+		})
+
+		document.body.appendChild($iframe)
+
+		$iframe.addEventListener('load', () => {
+			// 'load' will fire multiple times, due to in-frame navigation;
+			// we check for presence of elements on the page to determine
+			// which load event we're inside of
+
+			const $form = $iframe.contentDocument.querySelector('form#confirm')
+			const $confirmBtn = $form?.querySelector('[name=confirm]')
+
+			// is confirmation form
+			if ($confirmBtn) {
+				const $clone = $form.cloneNode(true)
+				const $confirm = $clone.querySelector('.inner') ?? $clone
+
+				// must be <input type=button name=confirm/cancel>
+				// in order for phpbb.confirm to recognize clicks
+				for (const $btn of $confirm.querySelectorAll('[type=submit]')) {
+					$btn.type = 'button'
+				}
+
+				phpbb.confirm($confirm.innerHTML, (val) => {
+					if (val) {
+						$confirmBtn.click()
+
+						phpbb.loadingIndicator()
+					} else {
+						$iframe.remove()
+					}
+				})
+
+				return
 			}
 
-			phpbb.clearLoadingTimeout()
-			$loadingIndicator.fadeOut(phpbb.alertTime)
-		} else if ($link = e.target.closest('a[href*="&rthanks="]')) {
+			const replacer = getReplacerForLink($link, $iframe.contentDocument)
+
+			// is navigation back to own page
+			if (replacer) {
+				replacer()
+
+				phpbb.clearLoadingTimeout()
+				$loadingIndicator.fadeOut(phpbb.alertTime)
+
+				$iframe.remove()
+
+				return
+			}
+		})
+	}
+
+	document.body.addEventListener('click', (e) => {
+		/** @type {HTMLAnchorElement} $link */
+		let $link
+
+		if (($link = e.target.closest('a[href*="&thanks="]'))) {
 			e.preventDefault()
-
-			const $loadingIndicator = phpbb.loadingIndicator()
-
-			const $iframe = Object.assign(document.createElement('iframe'), {
-				src: $link.href,
-				// Firefox will not submit form if iframe is `hidden` or
-				// `display: none`, so we place it out of view instead
-				style: 'width: 1; height: 1; position: fixed; top: -10000px',
-			})
-
-			$iframe.setAttribute('aria-hidden', 'true')
-
-			document.body.appendChild($iframe)
-
-			$iframe.addEventListener('load', () => {
-				// 'load' will fire multiple times, due to in-frame navigation;
-				// we check for presence of elements on the page to determine
-				// which load event we're inside of
-
-				const $form = $iframe.contentDocument.querySelector('form#confirm')
-				const $confirmBtn = $form?.querySelector('[name=confirm]')
-
-				// is confirmation form
-				if ($confirmBtn) {
-					const $clone = $form.cloneNode(true)
-					const $confirmContent = $clone.querySelector('.inner') ?? $clone
-
-					// must be <input type=button name=confirm/cancel>
-					// in order for phpbb.confirm to recognize clicks
-					for (const $btn of $confirmContent.querySelectorAll('[type=submit]')) {
-						$btn.type = 'button'
-					}
-
-					phpbb.confirm(
-						$confirmContent.innerHTML,
-						(val) => {
-							if (val) {
-								$confirmBtn.click()
-
-								phpbb.loadingIndicator()
-							} else {
-								$iframe.remove()
-							}
-						},
-					)
-
-					return
-				}
-
-				const replacer = getReplacerForLink($link, $iframe.contentDocument)
-
-				// is navigation back to own page
-				if (replacer) {
-					replacer()
-
-					phpbb.clearLoadingTimeout()
-					$loadingIndicator.fadeOut(phpbb.alertTime)
-
-					$iframe.remove()
-
-					return
-				}
-			})
+			thankHandler($link)
+		} else if (($link = e.target.closest('a[href*="&rthanks="]'))) {
+			e.preventDefault()
+			unthankHandler($link)
 		}
 	})
 })()

--- a/styles/all/theme/js/ajax.js
+++ b/styles/all/theme/js/ajax.js
@@ -1,0 +1,108 @@
+;(() => {
+	/**
+	 * @typedef {{
+	 * 		fadeOut: (ms: number) => JQuery,
+	 * }} JQuery
+	 */
+
+	/**
+	 * @type {{
+	 * 	phpbb: {
+	 * 		alertTime: number,
+	 * 		loadingIndicator: () => JQuery,
+	 * 		alert: (title: string, message: string) => JQuery,
+	 * 		clearLoadingTimeout: () => void,
+	 * 	},
+	 * 	thanksForPosts: {
+	 * 		l10n: {
+	 * 			errorTitle: string,
+	 * 			errorMessage: string,
+	 * 		},
+	 * 	},
+	 * }}
+	 */
+	const { phpbb, thanksForPosts: data } = window
+	const { l10n } = data
+
+	/**
+	 * @param {HTMLAnchorElement} link
+	 * @param {Document} doc
+	 */
+	const getReplacerForLink = ($link, doc) => {
+		/** @type {HTMLDivElement} */
+		const $post = $link.closest('.post')
+		const $replacement = doc.getElementById($post.id)
+
+		if ($replacement) {
+			$replacement.querySelector('.content').replaceWith($post.querySelector('.content'))
+
+			return () => $post.replaceWith($replacement)
+		}
+
+		return null
+	}
+
+	document.body.addEventListener('click', async (e) => {
+		/** @type {HTMLAnchorElement} link */
+		let $link
+
+		if ($link = e.target.closest('a[href*="&thanks="]')) {
+			e.preventDefault()
+
+			const $loadingIndicator = phpbb.loadingIndicator()
+			const res = await fetch($link.href)
+
+			if (res.ok) {
+				const res = await fetch(window.location.href)
+				const text = await res.text()
+
+				const doc = new DOMParser().parseFromString(text, 'text/html')
+
+				getReplacerForLink($link, doc)?.()
+			} else {
+				phpbb.alert(l10n.errorTitle, l10n.errorMessage)
+			}
+
+			phpbb.clearLoadingTimeout()
+			$loadingIndicator.fadeOut(phpbb.alertTime)
+		} else if ($link = e.target.closest('a[href*="&rthanks="]')) {
+			e.preventDefault()
+
+			const $loadingIndicator = phpbb.loadingIndicator()
+
+			const $iframe = document.createElement('iframe')
+			$iframe.src = $link.href
+			$iframe.hidden = true
+			document.body.appendChild($iframe)
+
+			$iframe.addEventListener('load', () => {
+				// 'load' will fire multiple times, due to in-frame navigation;
+				// we check for presence of elements on the page to determine
+				// which load event we're inside of
+
+				const $confirmBtn = $iframe.contentDocument.querySelector('#confirm [name=confirm]')
+
+				// is form
+				if ($confirmBtn) {
+					$confirmBtn.click()
+
+					return
+				}
+
+				const replacer = getReplacerForLink($link, $iframe.contentDocument)
+
+				// is navigation back to own page
+				if (replacer) {
+					replacer()
+
+					phpbb.clearLoadingTimeout()
+					$loadingIndicator.fadeOut(phpbb.alertTime)
+
+					$iframe.remove()
+
+					return
+				}
+			})
+		}
+	})
+})()

--- a/styles/all/theme/js/ajax.js
+++ b/styles/all/theme/js/ajax.js
@@ -71,9 +71,15 @@
 
 			const $loadingIndicator = phpbb.loadingIndicator()
 
-			const $iframe = document.createElement('iframe')
-			$iframe.src = $link.href
-			$iframe.hidden = true
+			const $iframe = Object.assign(document.createElement('iframe'), {
+				src: $link.href,
+				// Firefox will not submit form if iframe is `hidden` or
+				// `display: none`, so we place it out of view instead
+				style: 'width: 1; height: 1; position: fixed; top: -10000px',
+			})
+
+			$iframe.setAttribute('aria-hidden', 'true')
+
 			document.body.appendChild($iframe)
 
 			$iframe.addEventListener('load', () => {
@@ -87,7 +93,6 @@
 				// is confirmation form
 				if ($confirmBtn) {
 					const $clone = $form.cloneNode(true)
-
 					const $confirmContent = $clone.querySelector('.inner') ?? $clone
 
 					// must be <input type=button name=confirm/cancel>


### PR DESCRIPTION
Adds an optional AJAX mode (disabled by default) to allow thanking and un-thanking to update the UI directly, without leaving the page.

Behind the scenes, the JS simply fetches the HTML from the existing routes, submits the relevant forms inside hidden `iframe`s, and rewrites the existing elements with the updated DOM, so the added complexity is minimal (+184 lines, mostly JS). Any changes to themes, icons, translations, etc. are carried over from the non-AJAX UI, with no additional configuration required; this avoids, for example, the problems with icons from the 3rd-party extension, as reported in [this thread](https://www.phpbb.com/customise/db/extension/thanks_for_posts_2/support/topic/215506).

Demo:

![thanks](https://user-images.githubusercontent.com/26078826/160717959-a79edaa5-63fc-47e4-bbfc-b188a52342ce.gif)